### PR TITLE
Release of 2.1.0 (depends on rest-messenger 2.1.0)

### DIFF
--- a/checkup.sh
+++ b/checkup.sh
@@ -1,0 +1,7 @@
+echo
+echo "************** BUILDING FOR LATEST SPRING BOOT 2.x ************** "
+mvn clean install
+echo
+echo
+echo "************** BUILDING FOR SPRING BOOT 1.x ************** "
+mvn clean install -Dspring-boot.version=1.5.8.RELEASE

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <groupId>com.clearlydecoded</groupId>
   <artifactId>rest-messenger-demo</artifactId>
   <packaging>war</packaging>
-  <version>2.0.1</version>
+  <version>2.1.0-SNAPSHOT</version>
 
 
   <properties>
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>com.clearlydecoded</groupId>
       <artifactId>rest-messenger</artifactId>
-      <version>2.0.1</version>
+      <version>2.1.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <groupId>com.clearlydecoded</groupId>
   <artifactId>rest-messenger-demo</artifactId>
   <packaging>war</packaging>
-  <version>2.1.0-SNAPSHOT</version>
+  <version>2.1.0</version>
 
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>com.clearlydecoded</groupId>
       <artifactId>rest-messenger</artifactId>
-      <version>2.1.0-SNAPSHOT</version>
+      <version>2.1.0</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,25 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * Copyright 2018 Yaakov Chaikin (yaakov@ClearlyDecoded.com). Licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0. Unless required
+ * by applicable law or agreed to in writing, software distributed under the License is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
-  <parent>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.0.3.RELEASE</version>
-    <relativePath/>
-  </parent>
 
   <groupId>com.clearlydecoded</groupId>
   <artifactId>rest-messenger-demo</artifactId>
   <packaging>war</packaging>
   <version>2.1.0-SNAPSHOT</version>
 
-
   <properties>
-    <java.version>1.8</java.version>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <spring-boot.version>2.0.3.RELEASE</spring-boot.version>
   </properties>
+
+  <!-- Alternative to having spring boot as parent, but still manage dependencies. -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -57,6 +73,12 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring-boot.version}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>3.2.2</version>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/com/clearlydecoded/messenger/demo/message/GingerCookieOrder.java
+++ b/src/main/java/com/clearlydecoded/messenger/demo/message/GingerCookieOrder.java
@@ -18,9 +18,7 @@ import java.util.Objects;
  */
 public class GingerCookieOrder implements Message<GingerCookieOrderResponse> {
 
-  public static final String TYPE = "FirstAvailableGingerCookieOrder";
-
-  private final String type = TYPE;
+  private final String type = "FirstAvailableGingerCookieOrder";
 
   public GingerCookieOrder() {
   }

--- a/src/main/java/com/clearlydecoded/messenger/demo/message/GreetMeMessage.java
+++ b/src/main/java/com/clearlydecoded/messenger/demo/message/GreetMeMessage.java
@@ -10,6 +10,8 @@ package com.clearlydecoded.messenger.demo.message;
 
 import com.clearlydecoded.messenger.Message;
 import java.util.Objects;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 /**
  * Demo class that requests a greeting with a supplied name.
@@ -19,15 +21,15 @@ import java.util.Objects;
 public class GreetMeMessage implements Message<GreetMeMessageResponse> {
 
   /**
-   * Set up the required message type identifier like so.
-   * There are other ways to define it, but this approach is nice.
+   * String-based type identifier of this message that is unique system-wide.
    */
-  public static final String TYPE = "GreetMe";
-  private final String type = TYPE;
+  private final String type = "GreetMe";
 
   /**
    * The actual data we want to pass to the processor.
    */
+  @NotNull(message = "'myName' can't be null")
+  @Size(min = 2, message = "'myName' has to be at least 2 characters long")
   private String myName;
 
   /**

--- a/src/main/java/com/clearlydecoded/messenger/demo/message/MaxSugarOrder.java
+++ b/src/main/java/com/clearlydecoded/messenger/demo/message/MaxSugarOrder.java
@@ -9,6 +9,8 @@
 package com.clearlydecoded.messenger.demo.message;
 
 import com.clearlydecoded.messenger.Message;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -28,10 +30,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class MaxSugarOrder implements Message<MaxSugarOrderResponse> {
 
-  public static final String TYPE = "MaxSugarOrder";
+  private final String type = "MaxSugarOrder";
 
-  private final String type = TYPE;
-
+  @Min(value = 10, message = "'maxSugarInGrams' must be between 10 and 2000.")
+  @Max(value = 2000, message = "'maxSugarInGrams' must be between 10 and 2000.")
   private int maxSugarInGrams;
 
   @Override

--- a/src/main/java/com/clearlydecoded/messenger/demo/message/SugarComaCookieOrder.java
+++ b/src/main/java/com/clearlydecoded/messenger/demo/message/SugarComaCookieOrder.java
@@ -18,6 +18,12 @@ import java.util.Objects;
  */
 public class SugarComaCookieOrder implements Message<SugarComaCookieOrderResponse> {
 
+  /**
+   * Set up the required message type identifier like so.
+   * There are other ways to define it, but this approach is useful because this message will get
+   * processed by a processor that implements the MessageProcessor interface and this public static
+   * type makes it easy to use for a return type of getCompatibleMessageType method.
+   */
   public static final String TYPE = "SugarComaCookieOrder";
 
   private final String type = TYPE;

--- a/src/main/java/com/clearlydecoded/messenger/demo/processor/GreetMeMessageProcessor.java
+++ b/src/main/java/com/clearlydecoded/messenger/demo/processor/GreetMeMessageProcessor.java
@@ -11,6 +11,7 @@ package com.clearlydecoded.messenger.demo.processor;
 import com.clearlydecoded.messenger.AbstractMessageProcessor;
 import com.clearlydecoded.messenger.demo.message.GreetMeMessage;
 import com.clearlydecoded.messenger.demo.message.GreetMeMessageResponse;
+import javax.validation.Valid;
 import org.springframework.stereotype.Service;
 
 /**
@@ -23,7 +24,7 @@ public class GreetMeMessageProcessor extends
     AbstractMessageProcessor<GreetMeMessage, GreetMeMessageResponse> {
 
   @Override
-  public GreetMeMessageResponse process(GreetMeMessage message) {
+  public GreetMeMessageResponse process(@Valid GreetMeMessage message) {
 
     // This is where you write the actual business logic
     return new GreetMeMessageResponse("Hello " + message.getMyName());

--- a/src/main/java/com/clearlydecoded/messenger/demo/processor/MaxSugarOrderProcessor.java
+++ b/src/main/java/com/clearlydecoded/messenger/demo/processor/MaxSugarOrderProcessor.java
@@ -14,6 +14,7 @@ import com.clearlydecoded.messenger.demo.message.MaxSugarOrderResponse;
 import com.clearlydecoded.messenger.demo.model.Cookie;
 import com.clearlydecoded.messenger.demo.service.CookieStoreService;
 import java.util.List;
+import javax.validation.Valid;
 import lombok.Setter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -33,7 +34,7 @@ public class MaxSugarOrderProcessor extends
   private CookieStoreService cookieStoreService;
 
   @Override
-  public MaxSugarOrderResponse process(MaxSugarOrder message) {
+  public MaxSugarOrderResponse process(@Valid MaxSugarOrder message) {
     List<Cookie> cookies = cookieStoreService
         .giveMeCookiesUpToMaxSugar(message.getMaxSugarInGrams());
 


### PR DESCRIPTION
Coincides with release of rest-messenger 2.1.0 ([release notes](https://github.com/clearlydecoded/rest-messenger/releases/tag/v2.1.0))